### PR TITLE
fix(LINGUIST-363): Error logging and lowercase fix

### DIFF
--- a/src/common/exception.ts
+++ b/src/common/exception.ts
@@ -35,8 +35,15 @@ export class ValidationExc extends Exception {
         super(StatusCodes.BAD_REQUEST, "Wrong request content!", "");
 
         this.validation_error = [];
-        for (let detail of error.details) {
-            this.validation_error.push(detail.message);
+
+        // Check if error.details is iterable before attempting to iterate over it
+        if (error.details && typeof error.details[Symbol.iterator] === 'function') {
+            for (let detail of error.details) {
+                this.validation_error.push(detail.message);
+            }
+        } else {
+            // If error.details is not iterable, add a default error message
+            this.validation_error.push("Validation failed: unknown error");
         }
     }
 }

--- a/src/service/dictionary-service.ts
+++ b/src/service/dictionary-service.ts
@@ -11,14 +11,16 @@ import { FreeDictConfig } from "../utils/dictionary/config-free-dict";
 export class DictionaryService {
     search_word(wordList: string[]): Promise<any> {
         const promises = wordList.map((word: string) => {
+            const lowercaseWord = word.toLowerCase();
+
             return new Promise<DictionaryResponse>((resolve, reject) => {
                 const apiConfig = this.select_api();
 
-                axios(apiConfig.axiosConfig(word))
+                axios(apiConfig.axiosConfig(lowercaseWord))
                     .then((res) => {
                         apiConfig.handleErrors(res);
                         const edgeCaseResult: DictionaryResponse | null =
-                            apiConfig.handleEdgeCases(res, word);
+                            apiConfig.handleEdgeCases(res, lowercaseWord);
 
                         if (edgeCaseResult) {
                             resolve(edgeCaseResult);
@@ -27,10 +29,10 @@ export class DictionaryService {
                                 JSON.stringify(res.data)
                             );
                             const wordGroup: DictionaryWordGroup[] =
-                                apiConfig.extractDictData(word, dictResponse);
+                                apiConfig.extractDictData(lowercaseWord, dictResponse);
 
                             const result: DictionaryResponse = {
-                                [word]: { wordGroup },
+                                [lowercaseWord]: { wordGroup },
                             };
 
                             resolve(result);


### PR DESCRIPTION
There were two errors: 

- Error logging: when trying to get the definition of gibberish words (e.g., "off") the error logging mechanism would throw: `TypeError: error.details is not iterable
[...]
[nodemon] app crashed - waiting for file changes before starting...` and the service would just wait forever. 
I made very minor change and it seems to return errors correctly now -  though @elif-krvan should check it again because it may just be a band-aid. 

- Meriam webster does not return definitions if they are not all lowercase (e.g. "language" works but "Language" does not). We now convert words to lowercase before requesting their definition. 
